### PR TITLE
crop() now chainable and restores previous clipRect.

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -264,17 +264,17 @@ exports.crop = function( area, path ){
     height : area.height
   };
   var self = this;
-  this.page.set('clipRect', rect, function(){
-    self.pause.unpause('clipRect');
-    self.screenshot( path );
-    self.page.set("viewportSize",{
-      width: 1200,
-      height: 800
+  this.page.get('clipRect', function(err, prevClipRect){
+    self.page.set('clipRect', rect, function(){
+      self.screenshot(path);
+      self.page.set('clipRect', prevClipRect, function(){
+        self.pause.unpause('clipRect');
+      });
     });
-    return this;
   });
   this.pause.pause('clipRect');  
-}
+  return this;
+};
 
 exports.screenshot = function( path ){
   var self = this;


### PR DESCRIPTION
This is my first pull request on github so apologies if I've made any errors.

I had two problems using crop:
- crop killed the call chain because it didn't return self correctly.
- crop messed up future screenshots because it didn't restore the previous clipRect.

This patch fixes both problems for me. I tried to keep to your coding style.