### PR TITLE
Fix close when chaining

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1055,14 +1055,3 @@ exports.waitFor = function(fn, value) {
 			});
 	});
 };
-
-//**************************************************//
-// Cleanup
-//**************************************************//
-exports.close = function() {
-	debug('.close().');
-	var self = this;
-	return this.ready.then(function() {
-		return self.phantom.exit(0);
-	});
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,4 +168,20 @@ Object.keys(actions).forEach(function(name) {
 	};
 });
 
+//**************************************************//
+// Cleanup
+//**************************************************//
+Horseman.prototype.close = function() {
+	debug('.close().');
+	var self = this;
+	return this.ready.finally(function() {
+		return self.phantom.exit(0);
+	});
+};
+HorsemanPromise.prototype.close = function() {
+	return this.finally(function() {
+		return this.close();
+	});
+};
+
 module.exports = Horseman;

--- a/test/index.js
+++ b/test/index.js
@@ -1324,19 +1324,28 @@ describe('Horseman', function() {
 			horseman.close();
 		});
 
-		it('should be available when calling actions on horseman', function() {
-			horseman.open(serverUrl)
-				.should.have.properties(Object.keys(actions));
+		it('should be available when calling actions on horseman', function(done) {
+			var p = horseman.open(serverUrl);
+
+			p.finally(function() {
+				p.should.have.properties(Object.keys(actions));
+			}).nodeify(done);
 		});
 
-		it('should be available when calling actions on Promises', function() {
-			horseman.open(serverUrl).url()
-				.should.have.properties(Object.keys(actions));
+		it('should be available when calling actions on Promises', function(done) {
+			var p = horseman.open(serverUrl).url();
+
+			p.finally(function() {
+				p.should.have.properties(Object.keys(actions));
+			}).nodeify(done);
 		});
 
-		it('should be available when calling Promise methods', function() {
-			horseman.open(serverUrl).then(function() {})
-				.should.have.properties(Object.keys(actions));
+		it('should be available when calling Promise methods', function(done) {
+			var p = horseman.open(serverUrl).then(function() {});
+
+			p.finally(function() {
+				p.should.have.properties(Object.keys(actions));
+			}).nodeify(done);
 		});
 
 		it('should call close after rejection', function(done) {
@@ -1353,8 +1362,13 @@ describe('Horseman', function() {
 					throw new Error('Intentional Rejection');
 				})
 				.close()
+				.catch(function() {})
 				.finally(function() {
 					called.should.equal(true);
+				})
+				.then(function() {
+					// Don't call close twice
+					horseman.close = function() {};
 				})
 				.nodeify(done);
 		});

--- a/test/index.js
+++ b/test/index.js
@@ -1338,6 +1338,26 @@ describe('Horseman', function() {
 			horseman.open(serverUrl).then(function() {})
 				.should.have.properties(Object.keys(actions));
 		});
+
+		it('should call close after rejection', function(done) {
+			// Record if close gets called
+			var close = horseman.close;
+			var called = false;
+			horseman.close = function() {
+				called = true;
+				return close.apply(this, arguments);
+			}
+
+			horseman.open(serverUrl)
+				.then(function() {
+					throw new Error('Intentional Rejection');
+				})
+				.close()
+				.finally(function() {
+					called.should.equal(true);
+				})
+				.nodeify(done);
+		});
 	});
 
 });


### PR DESCRIPTION
When one of the Promises in a chain rejected before a `.close()`, `.close()` would never actually be called on the horseman instance.

Seeing as I always had my `.close()` in a finally (thus calling it even after a rejection), and so did the examples before chaining, I figured `.close()` should always be called. These changes make that happen.