### PR TITLE
Fix .upload()

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -637,7 +637,6 @@ exports.upload = function(selector, path) {
 	var self = this;
 	if (fs.existsSync(path)) {
 		return new HorsemanPromise(function(resolve, reject) {
-            console.log(self);
             self.page.uploadFile(selector, path, function() {
                 resolve();
                 debug(".upload() " + path + " into " + selector);

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -641,7 +641,7 @@ exports.upload = function(selector, path) {
                 resolve();
                 debug(".upload() " + path + " into " + selector);
             });
-		}).timeout(self.options.timeout);
+		});
 	} else {
 		debug(".upload() file path not valid.");
 		return Error("File path for upload is not valid.");

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -637,7 +637,7 @@ exports.upload = function(selector, path) {
 	var self = this;
 	if (fs.existsSync(path)) {
 		return new HorsemanPromise(function(resolve, reject) {
-            self.page.uploadFile(selector, path, function() {
+            return self.page.uploadFile(selector, path, function() {
                 resolve();
                 debug(".upload() " + path + " into " + selector);
             });

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -637,12 +637,11 @@ exports.upload = function(selector, path) {
 	var self = this;
 	if (fs.existsSync(path)) {
 		return new HorsemanPromise(function(resolve, reject) {
-			return self.page.evaluate(function(selector) {
-				self.page.uploadFile(selector, path, impatient(function() {
-					resolve();
-					debug(".upload() " + path + " into " + selector);
-				}, self.options.timeout));
-			});
+            console.log(self);
+            self.page.uploadFile(selector, path, function() {
+                resolve();
+                debug(".upload() " + path + " into " + selector);
+            });
 		});
 	} else {
 		debug(".upload() file path not valid.");

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -641,7 +641,7 @@ exports.upload = function(selector, path) {
                 resolve();
                 debug(".upload() " + path + " into " + selector);
             });
-		});
+		}).timeout(self.options.timeout);
 	} else {
 		debug(".upload() file path not valid.");
 		return Error("File path for upload is not valid.");


### PR DESCRIPTION
Hi! I ran into a problem recently: I can't use `.upload`. I ran tests and figured out that you disabled it because of some bug in **phantomjs 2**. But I really needed this stuff so I looked into the code and there is really something weird :)

You called `self.page.uploadFile` from browser's scope and also used `impatient` which isn't installed and used nowhere except this place. I stripped out those parts and it worked perfectly with **phantom 1.** that I use.

I didn't touch tests though. They seem a bit deprecated and Windows-bounded, I think it would be easier for you to fix them.

My point is: why can't I use this functionality with my phantomjs v1.9.8 if there is an issue with v2?

Thanks! Will be waiting for a review.