### PR TITLE
Do not try to exit PhantomJS when it failed to intitialize

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,7 +174,7 @@ Object.keys(actions).forEach(function(name) {
 Horseman.prototype.close = function() {
 	debug('.close().');
 	var self = this;
-	return this.ready.finally(function() {
+	return this.ready.then(function() {
 		return self.phantom.exit(0);
 	});
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1426,7 +1426,7 @@ describe('Horseman', function() {
 				.close()
 				.catch(function(e) {
 					// Make sure rejected by initialization error
-					e.should.have.property('path', BAD_PATH);
+					e.should.have.property('code', 'ENOENT');
 				})
 				.nodeify(done);
 		});

--- a/test/index.js
+++ b/test/index.js
@@ -1417,6 +1417,19 @@ describe('Horseman', function() {
 				})
 				.nodeify(done);
 		});
+
+		it('should not call exit in close after failed init', function(done) {
+			var BAD_PATH = 'notphantom';
+			var horseman = new Horseman({phantomPath: BAD_PATH});
+
+			horseman.open(serverUrl)
+				.close()
+				.catch(function(e) {
+					// Make sure rejected by initialization error
+					e.should.have.property('path', BAD_PATH);
+				})
+				.nodeify(done);
+		});
 	});
 
 });


### PR DESCRIPTION
When I was looking into #70, I found that the real error was being obscured by my code being dumb. With this the Promise will reject with the thing that caused the initialization to fail instead of a complaint from trying to call `.exit` on nothing.