### PR TITLE
Reject from open if Phantom status is 'fail'

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -51,9 +51,13 @@ exports.open = function(url) {
 		return new HorsemanPromise(function(resolve, reject) {
 			self.page.open(url, function(err, status) {
 				debug('.open: ' + url + ' - status: ' + status);
-				if (err) reject(err);
-				else if (status === 'fail') reject(status);
-				else resolve(status);
+				if (err) {
+					reject(err);
+				} else if (status === 'fail') {
+					reject(new Error('failed to open url'));
+				} else {
+					resolve(status);
+				}
 			});
 		});
 	})

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -54,7 +54,7 @@ exports.open = function(url) {
 				if (err) {
 					reject(err);
 				} else if (status === 'fail') {
-					reject(new Error('failed to open url'));
+					reject(new Error('Failed to open url: ' + url));
 				} else {
 					resolve(status);
 				}

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -52,6 +52,7 @@ exports.open = function(url) {
 			self.page.open(url, function(err, status) {
 				debug('.open: ' + url + ' - status: ' + status);
 				if (err) reject(err);
+				else if (status === 'fail') reject(status);
 				else resolve(status);
 			});
 		});

--- a/test/index.js
+++ b/test/index.js
@@ -70,6 +70,26 @@ function navigation(bool) {
 				.nodeify(done);
 		});
 
+		it('should reject on fail', function(done) {
+			var port = (process.env.port || defaultPort) + 1;
+			var requestUrl = hostname + ':' + port + '/';
+
+			var horseman = new Horseman({
+				injectJquery: bool
+			});
+			horseman
+				.open(requestUrl)
+				.then(function() {
+					throw new Error('fail status did not reject')
+				}, function (status) {
+					status.should.equal('fail');
+				})
+				.finally(function () {
+					horseman.close();
+				})
+				.nodeify(done);
+		});
+
 		it('should have a HTTP status code', function(done) {
 			var horseman = new Horseman({
 				injectJquery: bool

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,8 @@ var should = require('should');
 var parallel = require('mocha.parallel');
 
 var app, server, serverUrl;
+var hostname = 'http://localhost';
+var defaultPort = 4567;
 
 function navigation(bool) {
 
@@ -829,10 +831,10 @@ describe('Horseman', function() {
 	 */
 	before(function(done) {
 		app = express();
-		var port = process.env.port || 4567;
+		var port = process.env.port || defaultPort;
 		app.use(express.static(path.join(__dirname, 'files')));
 		server = app.listen(port, function() {
-			serverUrl = 'http://localhost:' + port + '/';;
+			serverUrl = hostname + ':' + port + '/';
 			done();
 		});
 	});

--- a/test/index.js
+++ b/test/index.js
@@ -81,8 +81,9 @@ function navigation(bool) {
 				.open(requestUrl)
 				.then(function() {
 					throw new Error('fail status did not reject')
-				}, function (status) {
-					status.should.equal('fail');
+				}, function (err) {
+					err.should.be.instanceOf(Error);
+					err.message.should.equal('failed to open url');
 				})
 				.finally(function () {
 					horseman.close();

--- a/test/index.js
+++ b/test/index.js
@@ -83,7 +83,7 @@ function navigation(bool) {
 					throw new Error('fail status did not reject')
 				}, function (err) {
 					err.should.be.instanceOf(Error);
-					err.message.should.equal('failed to open url');
+					err.message.should.equal('Failed to open url: ' + requestUrl);
 				})
 				.finally(function () {
 					horseman.close();


### PR DESCRIPTION
Phantom does not return an error for invalid page URLs, like when a host is offline or otherwise can't be reached. Instead, it returns a [Phantom fail status](http://phantomjs.org/api/webpage/method/open.html).

Currently, if a call to `horseman.open` fails in such a way, the promise is simply resolved, so subsequent calls are attempted (for example, `.screenshot()`) and silently fail (in that case, resulting in an empty image). 

You could add a check in your application for the resolved status code (*fail* here), or even make a call to `.status()` (which returns null, in this case), or possibly even something else, but it seems more correct to reject the promise from within `open`.

This PR adds a check in `.open` for the `fail` status from Phantom, and rejects if found.

Also added a test case, which simply increments the port number by 1, which should result in a request failure. I'm open to other suggestions for making the `open` request fail though if you don't think this is sufficient.

Closes #65