### PR TITLE
Fixing navigationRequested callback to include parameters from documentation

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -976,7 +976,7 @@ exports.on = function(eventType, callback) {
 			self.page.onTimeout = callback;
 		} else if (eventType === "navigationRequested") {
 			self.page.onNavigationRequested = function(result) {
-				callback(result[0])
+				callback.apply(null, result);
 			}
 		} else if (eventType === "tabCreated") {
 			self.onTabCreated = callback;

--- a/test/index.js
+++ b/test/index.js
@@ -1218,8 +1218,11 @@ describe('Horseman', function() {
 			var fired = false;
 
 			horseman
-				.on("navigationRequested", function(url) {
+				.on("navigationRequested", function(url, type, willNavigate, isMain) {
 					fired = (url === "https://www.yahoo.com/");
+					type.should.equal("Other");
+					willNavigate.should.be.true;
+					isMain.should.be.true;
 				})
 				.open('http://www.yahoo.com')
 				.then(function() {


### PR DESCRIPTION
I noticed the callback for the navigationRequested only had the first parameter being passed through.
As per the node-horseman documentation, it should have the following params:

- `navigationRequested` - callback(url, type, willNavigate, main)


I also updated the unit test to check for these params.