### PR TITLE
Fix New Pages/Tabs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,7 @@ The available options are:
 * `interval`: how frequently to poll for page load state, default `50` ms.
 * `port`: port to mount the phantomjs instance to, default `12401`.
 * `loadImages`: load all inlined images, default `true`.
+* `switchToNewTab`: switch to new tab when created, default `false`.
 * `cookiesFile`: A file where to store/use cookies.
 * `ignoreSSLErrors`: ignores SSL errors, such as expired or self-signed certificate errors, default `true`.
 * `sslProtocol`: sets the SSL protocol for secure connections `[sslv3|sslv2|tlsv1|any]`, default `any`.
@@ -400,7 +401,7 @@ Wait until the `fn` evaluated on the page returns `value`.
 Horseman supports multiple tabs being open at the same time.
 
 #### .openTab(url)
-Open a url in a new tab. Fires a `tabCreated` event.
+Open a url in a new tab. Fires a `tabCreated` event. Also, the newly created tab becomes the current tab.
 
 #### .tabCount()
 Returns the number of tabs currently open.

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -990,6 +990,10 @@ exports.on = function(eventType, callback) {
 				self.responses[response.url] = response.status;
 				callback(response);
 			};
+		} else if (eventType == "pageCreated") {
+			self.page.onPageCreated = function(page) {
+				self.pageMaker(page).then(callback);
+			};
 		} else if (eventType == "loadFinished") {
 			self.page.onLoadFinished2 = callback;
 		} else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ Horseman.prototype.pageMaker = function(_page) {
 		function setupPage(page) {
 			debug('page created')
 
-			page.onPageCreated = self.pageMaker;
+			page.onPageCreated = self.pageMaker.bind(self);
 
 			page.onResourceReceived = function(response) {
 				self.responses[response.url] = response.status;

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ var DEFAULTS = {
 	loadImages: true,
 	sslProtocol: "any", //sslv3, sslv2, tlsv1, any
 	webSecurity: true,
-	injectJquery: true
+	injectJquery: true,
+	switchToNewTab: false
 };
 
 
@@ -91,11 +92,11 @@ var Horseman = function(options) {
 
 };
 
-Horseman.prototype.pageMaker = function(page) {
+Horseman.prototype.pageMaker = function(_page) {
 	var self = this;
 	return new HorsemanPromise(function(resolve, reject) {
-		if (page) {
-			setupPage(page);
+		if (_page) {
+			setupPage(_page);
 		} else {
 			self.phantom.createPage(function(err, page) {
 				if (err) {
@@ -156,7 +157,9 @@ Horseman.prototype.pageMaker = function(page) {
 			resolve(page);
 		}
 	}).tap(function attachPage(page) {
-		self.page = page;
+		if (!_page || self.options.switchToNewTab) {
+			self.page = page;
+		}
 		self.tabs.push(page);
 
 		self.onTabCreated();

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,65 +91,76 @@ var Horseman = function(options) {
 
 };
 
-Horseman.prototype.pageMaker = function() {
+Horseman.prototype.pageMaker = function(page) {
 	var self = this;
 	return new HorsemanPromise(function(resolve, reject) {
-		self.phantom.createPage(function(err, page) {
-			if (err) {
-				throw err;
-			} else {
-				debug('page created')
-				self.page = page;
-				self.tabs.push(page);
-				
-				self.onTabCreated();
-				
-				self.page.onResourceReceived = function(response) {
-					self.responses[response.url] = response.status;
-				}.bind(self);
+		if (page) {
+			setupPage(page);
+		} else {
+			self.phantom.createPage(function(err, page) {
+				if (err) {
+					throw err;
+				} else {
+					setupPage(page);
+				}
+			});
+		}
 
-				self.page.onLoadFinished = function() {
+		function setupPage(page) {
+			debug('page created')
+
+			page.onPageCreated = self.pageMaker;
+
+			page.onResourceReceived = function(response) {
+				self.responses[response.url] = response.status;
+			}.bind(self);
+
+			page.onLoadFinished = function() {
+				var self = this;
+				self.waitingForNextPage = false;
+				debug('phantomjs onLoadFinished triggered.');
+				if (self.options.injectJquery) {
 					var self = this;
-					self.waitingForNextPage = false;
-					debug('phantomjs onLoadFinished triggered.');
-					if (self.options.injectJquery) {
-						var self = this;
-						self.ready = self
-							.evaluate(function() {
-								return (typeof window.jQuery !== "undefined");
-							})
-							.then(function(hasJquery) {
-								if (!hasJquery) {
-									var jQueryLocation = path.join(__dirname, "../files/jquery-2.1.1.min.js");
-									return new HorsemanPromise(function(resolve, reject) {
-										self.page.injectJs(jQueryLocation, function() {
-											debug('injected jQuery');
-											if (self.page.onLoadFinished2) {
-												self.page.onLoadFinished2();
-											}
-											resolve();
-										})
-									});
+					self.ready = self
+						.evaluate(function() {
+							return (typeof window.jQuery !== "undefined");
+						})
+						.then(function(hasJquery) {
+							if (!hasJquery) {
+								var jQueryLocation = path.join(__dirname, "../files/jquery-2.1.1.min.js");
+								return new HorsemanPromise(function(resolve, reject) {
+									page.injectJs(jQueryLocation, function() {
+										debug('injected jQuery');
+										if (page.onLoadFinished2) {
+											page.onLoadFinished2();
+										}
+										resolve();
+									})
+								});
 
-								} else {
-									debug("jQuery not injected - already exists on page");
-									if (self.page.onLoadFinished2) {
-										self.page.onLoadFinished2();
-									}
-									resolve();
+							} else {
+								debug("jQuery not injected - already exists on page");
+								if (page.onLoadFinished2) {
+									page.onLoadFinished2();
 								}
-							})
-					} else {
-						if (self.page.onLoadFinished2) {
-							self.page.onLoadFinished2();
-						}
+								resolve();
+							}
+						})
+				} else {
+					if (page.onLoadFinished2) {
+						page.onLoadFinished2();
 					}
-				}.bind(self);
+				}
+			}.bind(self);
 
-				resolve(page);
-			}
-		});
-	})
+			resolve(page);
+		}
+	}).tap(function attachPage(page) {
+		self.page = page;
+		self.tabs.push(page);
+
+		self.onTabCreated();
+	});
 }
 
 /**

--- a/test/files/newtab.html
+++ b/test/files/newtab.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Horseman new tab</title>
+</head>
+</html>

--- a/test/files/opennewtab.html
+++ b/test/files/opennewtab.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Horseman test link open new tab</title>
+</head>
+<a href="./newtab.html" target="new-tab" id="newtab">Open new tab</a>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -1358,6 +1358,48 @@ describe('Horseman', function() {
 				.nodeify(done);
 		});
 
+		it('should have tabs opened by links', function() {
+			var horseman = new Horseman();
+			return horseman
+				.open(serverUrl + "opennewtab.html")
+				.click('a#newtab')
+				.tabCount()
+				.then(function(count) {
+					count.should.equal(2);
+				})
+				.close();
+		});
+
+		describe('swtichToNewTab option', function() {
+
+			it('should default to not switching tab', function() {
+				var horseman = new Horseman();
+				return horseman
+					.open(serverUrl + "opennewtab.html")
+					.click('a#newtab')
+					.title()
+					.then(function(title) {
+						title.should.equal('Horseman test link open new tab');
+					})
+					.close();
+			});
+
+			it('should switch tab when true', function () {
+				var horseman = new Horseman({
+					switchToNewTab: true
+				});
+				return horseman
+					.open(serverUrl + "opennewtab.html")
+					.click('a#newtab')
+					.title()
+					.then(function(title) {
+						title.should.equal('Horseman new tab');
+					})
+					.close();
+			});
+
+		});
+
 	});
 
 	describe('Chaining', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1363,6 +1363,7 @@ describe('Horseman', function() {
 			return horseman
 				.open(serverUrl + "opennewtab.html")
 				.click('a#newtab')
+				.waitForNextPage()
 				.tabCount()
 				.then(function(count) {
 					count.should.equal(2);
@@ -1377,6 +1378,7 @@ describe('Horseman', function() {
 				return horseman
 					.open(serverUrl + "opennewtab.html")
 					.click('a#newtab')
+					.waitForNextPage()
 					.title()
 					.then(function(title) {
 						title.should.equal('Horseman test link open new tab');
@@ -1391,6 +1393,7 @@ describe('Horseman', function() {
 				return horseman
 					.open(serverUrl + "opennewtab.html")
 					.click('a#newtab')
+					.waitForNextPage()
 					.title()
 					.then(function(title) {
 						title.should.equal('Horseman new tab');


### PR DESCRIPTION
When a page is created by something besides horseman (e.g., clicking a link), horseman is unaware of it. I found this when using horseman for something with @wang701.

This makes horseman add any created pages to the list of tabs. Also it adds an option for whether or not to switch to new tabs, and it defaults to false to be closer to the current behavior.

There are no tests... If I find time I might be able to make some.