### PR TITLE
Remove ignoreSSLErrors and webSecurity from defaults

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,20 +46,23 @@ Note: Make sure PhantomJS is available in your path, or use the `phantomPath` op
 Create a new instance that can navigate around the web.
 
 The available options are:
-* `clientScripts` an array of local javascript files to load onto each page.
-* `timeout`: how long to wait for page loads or wait periods, default `5000` ms.
-* `interval`: how frequently to poll for page load state, default `50` ms.
-* `port`: port to mount the phantomjs instance to, default `12401`.
-* `loadImages`: load all inlined images, default `true`.
-* `cookiesFile`: A file where to store/use cookies.
-* `ignoreSSLErrors`: ignores SSL errors, such as expired or self-signed certificate errors.
-* `sslProtocol`: sets the SSL protocol for secure connections `[sslv3|sslv2|tlsv1|any]`, default `any`.
-* `webSecurity`: enables web security and forbids cross-domain XHR.
-* `injectJquery`: whether or not jQuery is automatically loaded into each page. Default is `true`. If jQuery is already present on the page, it is not injected.
-* `proxy`: specify the proxy server to use `address:port`, default not set.
-* `proxyType`: specify the proxy server type `[http|socks5|none]`, default not set.
-* `proxyAuth`: specify the auth information for the proxy `user:pass`, default not set.
-* `phantomPath`: If PhantomJS is not installed in your path, you can use this option to specify the executable's location.
+
+Option | Default | Description
+------ | ------- | -----------
+timeout | 5000 | How long to wait for page loads or wait periods, in ms
+interval | 50 | How frequently to poll for page load state, in ms
+port | 12401 | Port to mount the phantomjs instance to
+loadImages | true | Load all inlined images
+sslProtocol | any | Sets the SSL protocol for secure connections `[sslv3|sslv2|tlsv1|any]`
+injectJquery | true | Whether or not jQuery is automatically loaded into each page (only if jQuery doesn't already exist)
+ignoreSSLErrors | | Ignores SSL errors, such as expired or self-signed certificate errors
+webSecurity | | Enables web security and forbids cross-domain XHR
+phantomPath | | If PhantomJS is not installed in your path, you can use this option to specify the executable's location.
+clientScripts | | An array of local javascript files to load onto each page
+cookiesFile | | A file where to store/use cookies
+proxy | | Specify the proxy server to use `address:port`
+proxyType | | Specify the proxy server type `[http|socks5|none]`
+proxyAuth | | Specify the auth information for the proxy `user:pass`
 
 ### Cleanup
 Be sure to `.close()` each Horseman instance when you're done with it!

--- a/Readme.md
+++ b/Readme.md
@@ -52,9 +52,9 @@ The available options are:
 * `port`: port to mount the phantomjs instance to, default `12401`.
 * `loadImages`: load all inlined images, default `true`.
 * `cookiesFile`: A file where to store/use cookies.
-* `ignoreSSLErrors`: ignores SSL errors, such as expired or self-signed certificate errors, default `true`.
+* `ignoreSSLErrors`: ignores SSL errors, such as expired or self-signed certificate errors.
 * `sslProtocol`: sets the SSL protocol for secure connections `[sslv3|sslv2|tlsv1|any]`, default `any`.
-* `webSecurity`: enables web security and forbids cross-domain XHR, default `true`.
+* `webSecurity`: enables web security and forbids cross-domain XHR.
 * `injectJquery`: whether or not jQuery is automatically loaded into each page. Default is `true`. If jQuery is already present on the page, it is not injected.
 * `proxy`: specify the proxy server to use `address:port`, default not set.
 * `proxyType`: specify the proxy server type `[http|socks5|none]`, default not set.

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,8 @@ var DEFAULTS = {
 	port: 12405,
 	weak: true,
 	clientScripts: [],
-	ignoreSSLErrors: true,
 	loadImages: true,
 	sslProtocol: "any", //sslv3, sslv2, tlsv1, any
-	webSecurity: true,
 	injectJquery: true
 };
 
@@ -51,12 +49,16 @@ var Horseman = function(options) {
 	debug('.setup() creating phantom instance on %s', this.options.port);
 
 	var phantomOptions = {
-		'ignore-ssl-errors': this.options.ignoreSSLErrors,
 		'load-images': this.options.loadImages,
-		'ssl-protocol': this.options.sslProtocol,
-		'web-security': this.options.webSecurity
+		'ssl-protocol': this.options.sslProtocol
 	};
 
+	if (typeof this.options.ignoreSSLErrors !== "undefined") {
+		phantomOptions['ignore-ssl-errors'] = this.options.ignoreSSLErrors;
+	}
+	if (typeof this.options.webSecurity !== "undefined") {
+		phantomOptions['web-security'] = this.options.webSecurity;
+	}
 	if (typeof this.options.proxy !== "undefined") {
 		phantomOptions.proxy = this.options.proxy;
 	}


### PR DESCRIPTION
Closes #99 

Both options are not specified by default, but can still be passed in if the user needs them

- Ignore both settings by default
- Update default value in readme
- Use table for readme

The last bit I thought might be helpful, it's a little easier to see which defaults are defined.