### PR TITLE
Check if __horseman exists on window object in browser before evaluate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.js]
+indent_style = tab
+
+[{package.json,.travis.yml,*.md}]
+indent_style = space
+indent_size = 2

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+fail_on_violations: true
+
+jshint:
+  config_file: .jshintrc

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+	"node": true,
+	"browser": true,
+	"mocha": true,
+	"globals" : {
+		"prompt": false,
+		"alert": false,
+		"jQuery": false,
+		"$": false,
+		"Promise": true,
+		"__horseman": true,
+		"___obj": true
+	},
+	"sub": true,
+	"boss": true,
+	"quotmark": "single",
+	"evil": true,
+	"maxlen": 80,
+	"validthis": true,
+	"strict": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - '4'
   - '5'
   - '6'
+  - '7'
 sudo: false
 before_install:
   sh -c 'npm install phantomjs-prebuilt@$PHANTOMJS || npm install phantomjs@$PHANTOMJS'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - '0.12'
   - '4'
   - '5'
+  - '6'
 sudo: false
 before_install:
   sh -c 'npm install phantomjs-prebuilt@$PHANTOMJS || npm install phantomjs@$PHANTOMJS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 3.2.0 - 2016-10-21
+### Added
+- `diskCache` and `diskCachePath` options - thanks @efernandesng
+
 ## 3.1.1 - 2016-06-17
 Republish 3.1.0 without unwanted files which broke Windows installation
 

--- a/Readme.md
+++ b/Readme.md
@@ -75,7 +75,6 @@ Create a new instance that can navigate around the web.
 
 The available options are:
 
-  * `clientScripts` an array of local JavaScript files to load onto each page.
   * `timeout`: how long to wait for page loads or wait periods,
     default `5000` ms.
   * `interval`: how frequently to poll for page load state, default `50` ms.

--- a/examples/links.js
+++ b/examples/links.js
@@ -25,11 +25,11 @@ function hasNextPage(){
 }
 
 function scrape(){
-	
+
 	return new Promise( function( resolve, reject ){
 		return getLinks()
 		.then(function(newLinks){
-			
+
 			links = links.concat(newLinks);
 
 			if ( links.length < 30 ){
@@ -40,7 +40,7 @@ function scrape(){
 							.click("#pnnext")
 							.wait(1000)
 							.then( scrape );
-					} 
+					}
 				});
 			}
 		})
@@ -52,7 +52,7 @@ horseman
 	.userAgent("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0")
 	.open("http://www.google.com")
 	.type("input[name='q']","horseman")
-	.click("button:contains('Google Search')")
+	.click("input[value='Google Search']")
 	.keyboardEvent("keypress",16777221)
 	.waitForSelector("div.g")
 	.then( scrape )

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -838,6 +838,9 @@ exports.evaluate = function(fn) {
 		// Make dumy error to make evaluate rejections more debuggable
 		var stack = HorsemanPromise.reject(new Error('See next line'));
 		var res = evaluate(function evaluate(fnstr, hasCb, args) {
+				if(!window.__horseman) {
+					window.__horseman = {};
+				}
 				__horseman.cbargs = undefined;
 				var done = function done(err, res) {
 					if (__horseman.cbargs) { return; }

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,6 @@ var DEFAULTS = {
 	timeout: 5000,
 	interval: 50,
 	weak: true,
-	clientScripts: [],
 	loadImages: true,
 	sslProtocol: 'any', //sslv3, sslv2, tlsv1, any
 	injectJquery: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,7 @@ var Horseman = function Horseman(options) {
 	this.targetUrl = null;
 
 	// Store the HTTP status code for resources requested.
-	this.responses = [];
+	this.responses = {};
 
 	this.tabs = [];
 	this.onTabCreated = noop;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-horseman",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Run PhantomJS from Node",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "should": "^8.2.2"
   },
   "scripts": {
+    "lint": "jshint .",
     "test": "mocha -R spec"
   },
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -2010,13 +2010,13 @@ describe('Horseman', function() {
 				proxy: 'localhost:' + PROXY_PORT,
 				proxyType: 'http',
 			});
-			var hadHeader = 'truthy';
+			var hadHeader = false;
 			return horseman
 				.on('resourceReceived', function(resp) {
 					var hasHeader = resp.headers.some(function(header) {
 						return header.name === PROXY_HEADER;
 					});
-					hadHeader = hadHeader && hasHeader;
+					hadHeader = hadHeader || hasHeader;
 				})
 				.open('http://www.google.com')
 				.close()
@@ -2032,14 +2032,14 @@ describe('Horseman', function() {
 			if (phantomVersion.major < 2) {
 				this.skip('setProxy requires PhantomJS 2.0 or greater');
 			}
-			var hadHeader = 'truthy';
+			var hadHeader = false;
 			return horseman
 				.setProxy('localhost', PROXY_PORT)
 				.on('resourceReceived', function(resp) {
 					var hasHeader = resp.headers.some(function(header) {
 						return header.name === PROXY_HEADER;
 					});
-					hadHeader = hadHeader && hasHeader;
+					hadHeader = hadHeader || hasHeader;
 				})
 				.open('http://www.google.com')
 				.then(function() {


### PR DESCRIPTION
Fixing "ReferenceError: Can't find variable: __horseman".

Fairly complex Hapi.js API communicating with various websites via Horseman depending on user actions. The issue pops up because [window.__horseman init](https://github.com/johntitus/node-horseman/blob/e79acde57fc122000ea87bd08c78ff06d65534f9/lib/index.js#L367) does not run as the API answers to users killing the promise chain before it reaches this init. On subsequent actions with same Horseman instance running evaluate does not find the [__horseman](https://github.com/johntitus/node-horseman/blob/e79acde57fc122000ea87bd08c78ff06d65534f9/lib/actions.js#L841) in browser and the whole process fails.

Possibly better future solutions could be @awlayton [TODO: Consolidate into one page.evaluate?](https://github.com/johntitus/node-horseman/blame/e79acde57fc122000ea87bd08c78ff06d65534f9/lib/index.js#L271) and not adding the window.__horseman before we need it (only in evaluate).

Thanks!
