### PR TITLE
Implement waitFor with setTimeout instead of setInterval

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1631,11 +1631,10 @@ function waitForPage(page, fn) {
 	return this.ready.then(function() {
 		return new HorsemanPromise(function(resolve, reject) {
 			var start = Date.now();
-			var checkInterval = setInterval(function waitForCheck() {
+			(function waitForCheck() {
 				var _page = page || self.page;
 				var diff = Date.now() - start;
 				if (diff > self.options.timeout) {
-					clearInterval(checkInterval);
 					debug('.waitFor() timed out');
 					if (typeof _page.onTimeout === 'function') {
 						_page.onTimeout('waitFor');
@@ -1655,16 +1654,16 @@ function waitForPage(page, fn) {
 						.then(function(res) {
 							if (res === value) {
 								debug('.waitFor() completed successfully');
-								clearInterval(checkInterval);
 								resolve();
+							} else {
+								setTimeout(waitForCheck, self.options.interval);
 							}
 						})
 						.catch(function(err) {
-							clearInterval(checkInterval);
 							reject(err);
 						});
 				}
-			}, self.options.interval);
+			})();
 		});
 	});
 }


### PR DESCRIPTION
I met this issue not long after I deployed my application using node-horseman to production: I see lots of _waitFor() completed successfully_ fired for one `waitFor` task in the log.

I think we should use `setTimeout` here so the next check will not be fired before the previous one completed.
