### PR TITLE
Fix boundingRectangle() for sites with jQuery but not $

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -366,7 +366,7 @@ exports.boundingRectangle = function(selector) {
 	var self = this;
 	return this.__evaluate(function boundingRectangle(selector) {
 		if (window.jQuery) {
-			return $(selector)[0].getBoundingClientRect();
+			return jQuery(selector)[0].getBoundingClientRect();
 		} else {
 			var element = document.querySelector(selector);
 			return element.getBoundingClientRect();


### PR DESCRIPTION
use `jQuery` instead of `$`, for pages that already have jQuery present but not available as `$`

Example:
```javascript
var Horseman = require('node-horseman');
var horseman = new Horseman();

horseman
	.open('http://247wallst.com/')
	.boundingRectangle('div#headerbar')
	.log()
	.close();

```