### PR TITLE
Support arbitrary PhantomJS options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,6 +107,11 @@ The available options are:
     default not set.
   * `phantomPath`: If PhantomJS is not installed in your path,
     you can use this option to specify the executable's location.
+  * `phantomOptions`: Explicit PhantomJS options, e.g.
+    `{'ssl-certificates-path': 'ca.pem'}`.
+    For a complete list refer to the [PhantomJS command line interface](
+    http://phantomjs.org/api/command-line.html).
+    **These options have precedence over options implicitly set by Horseman.**
   * `debugPort`: Enable web inspector on specified port, default not set.
   * `debugAutorun`: Autorun on launch when in debug mode, default is true.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,6 +133,13 @@ var Horseman = function Horseman(options) {
 		}
 	}
 
+	Object.keys(this.options.phantomOptions || {}).forEach(function (key) {
+		if (typeof phantomOptions[key] !== 'undefined') {
+			debug('Horseman option ' + key + ' overridden by phantomOptions');
+		}
+		phantomOptions[key] = this.options.phantomOptions[key];
+	}.bind(this));
+
 	var instantiationOptions = {
 		parameters: phantomOptions
 	};

--- a/test/index.js
+++ b/test/index.js
@@ -163,6 +163,22 @@ function navigation(bool) {
 				.be.above(0);
 		});
 
+		it('should pass custom options to Phantom', function() {
+			var horseman = new Horseman({
+				timeout: defaultTimeout,
+				injectJquery: bool,
+				ignoreSSLErrors: true,
+				phantomOptions: {
+					'ignore-ssl-errors': false
+				}
+			});
+			return horseman
+				.open('https://expired.badssl.com')
+				.close()
+				.should
+				.be.rejected();
+		});
+
 		it('should set the viewport', function() {
 			var horseman = new Horseman({
 				timeout: defaultTimeout,


### PR DESCRIPTION
Using these modifications to pass SSL options.

Should allow to close https://github.com/johntitus/node-horseman/issues/181 .