### PR TITLE
Add action-specific timeout 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -667,10 +667,9 @@ Alternative signature for .waitFor, with extra options.
 // until true (or whatever else you specified) is returned
 horseman
   .waitFor({
-    fn : function (selector, count) {
+    fn : function waitForSelectorCount(selector, count) {
       return $(selector).length >= count
     },
-    fname : 'waitForSelectorCount',
     args : ['.some-selector', 2],
     value : true
   })

--- a/Readme.md
+++ b/Readme.md
@@ -632,9 +632,10 @@ a timeout event will be fired and the Promise for the action will reject.
 
 Wait for `ms` milliseconds e.g. `.wait(5000)`
 
-#### .waitForNextPage()
+#### .waitForNextPage([options])
 
 Wait until a page finishes loading, typically after a `.click()`.
+`options` can have be `{timeout: 5000}` to define an action-specific timeout.
 
 #### .waitForSelector(selector, [options])
 
@@ -678,7 +679,6 @@ horseman
 
 `fn` : function to execute, mandatory
 `args` : `fn` arguments
-`fname` : function name
 `value` : Wait until the `fn` evaluated on the page returns the *specified* `value`.
 `timeout` : specific timeout
 

--- a/Readme.md
+++ b/Readme.md
@@ -658,7 +658,30 @@ horseman
   // last argument (true here) is what return value to wait for
 ```
 
-`fn.timeout` can be defined to be used as an action-specific timeout.
+#### .waitFor(options)
+
+Alternative signature for .waitFor, with extra options.
+
+```js
+// This will call the function in the browser repeatedly
+// until true (or whatever else you specified) is returned
+horseman
+  .waitFor({
+    fn : function (selector, count) {
+      return $(selector).length >= count
+    },
+    fname : 'waitForSelectorCount',
+    args : ['.some-selector', 2],
+    value : true
+  })
+  // last argument (true here) is what return value to wait for
+```
+
+`fn` : function to execute, mandatory
+`args` : `fn` arguments
+`fname` : function name
+`value` : Wait until the `fn` evaluated on the page returns the *specified* `value`.
+`timeout` : specific timeout
 
 ### Frames
 

--- a/Readme.md
+++ b/Readme.md
@@ -636,10 +636,12 @@ Wait for `ms` milliseconds e.g. `.wait(5000)`
 
 Wait until a page finishes loading, typically after a `.click()`.
 
-#### .waitForSelector(selector)
+#### .waitForSelector(selector, [options])
 
 Wait until the element `selector` is present,
 e.g., `.waitForSelector('#pay-button')`
+
+`options` can have be `{timeout: 5000}` to define an action-specific timeout.
 
 #### .waitFor(fn, \[arg1, arg2,...\], value)
 
@@ -655,6 +657,8 @@ horseman
   }, '.some-selector', 2, true)
   // last argument (true here) is what return value to wait for
 ```
+
+`fn.timeout` can be defined to be used as an action-specific timeout.
 
 ### Frames
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1551,12 +1551,20 @@ exports.wait = function(milliseconds) {
 /**
  * Wait for a page load to occur
  * @throws Horseman.TimeoutError
+ * @param {object} options
+ * @param {number} [options.timeout=undefined] - timeout options
  * @emits Horseman#timeout
  */
-exports.waitForNextPage = function() {
+exports.waitForNextPage = function(options) {
 	debug('.waitForNextPage()');
 	var self = this;
 	var startCnt = self.lastActionPageCnt;
+	var timeout;
+	if(typeof(options) !== "undefined" && typeof(options.timeout)  === "number"){
+		timeout = options.timeout;
+	} else {
+		timeout = self.options.timeout;
+	}
 	return this.ready.then(function() {
 		var start = Date.now();
 		return new HorsemanPromise(function(resolve, reject) {
@@ -1567,7 +1575,7 @@ exports.waitForNextPage = function() {
 						resolve();
 					} else {
 						var diff = Date.now() - start;
-						if (diff > self.options.timeout) {
+						if (diff > timeout) {
 							clearInterval(waiting);
 							debug('.waitForNextPage() timed out');
 							if (typeof self.page.onTimeout === 'function') {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1647,12 +1647,12 @@ function waitForPage(page, optsOrFn) {
 	var args, value, fname, timeout = self.options.timeout, fn;
 
 	if(typeof optsOrFn === "function"){
-		  fn = optsOrFn;
+			fn = optsOrFn;
 			args = Array.prototype.slice.call(arguments);
 			value = args.pop();
 			fname = fn.name || '<anonymous>';
 	} else if(typeof optsOrFn === "object"){
-		  fn = optsOrFn.fn;
+			fn = optsOrFn.fn;
 			args = [page, fn].concat(optsOrFn.args || []);
 			value = optsOrFn.value;
 			fname = fn.name || '<anonymous>';

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1589,13 +1589,18 @@ exports.waitForNextPage = function() {
  * @throws Horseman.TimeoutError
  * @emits Horseman#timeout
  */
-exports.waitForSelector = function(selector) {
-	debug('.waitForSelector()', selector);
+exports.waitForSelector = function(selector, options) {
+	debug('.waitForSelector()', selector, options);
 	var elementPresent = function elementPresent(selector) {
 		var els = window.jQuery ?
 				jQuery(selector) : document.querySelectorAll(selector);
 		return els.length > 0;
 	};
+
+	if(typeof(options) !== "undefined" && typeof(options.timeout)  === "number"){
+		elementPresent.timeout = options.timeout;
+	}
+
 	return this.waitFor(elementPresent, selector, true).then(function() {
 		debug('.waitForSelector() complete');
 	});
@@ -1626,6 +1631,7 @@ function waitForPage(page, fn) {
 	var args = Array.prototype.slice.call(arguments);
 	var value = args.pop();
 	var fname = fn.name || '<anonymous>';
+	var timeout = fn.timeout || self.options.timeout;
 
 	debug.apply(debug, ['.waitFor()', fname].concat(args.slice(2)));
 	return this.ready.then(function() {
@@ -1634,7 +1640,7 @@ function waitForPage(page, fn) {
 			var checkInterval = setInterval(function waitForCheck() {
 				var _page = page || self.page;
 				var diff = Date.now() - start;
-				if (diff > self.options.timeout) {
+				if (diff > timeout) {
 					clearInterval(checkInterval);
 					debug('.waitFor() timed out');
 					if (typeof _page.onTimeout === 'function') {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1636,7 +1636,6 @@ exports.waitFor = function() {
  * @param {function | object} optsOrFn - If optsOrFn is a function, use the classic signature waitForPage(page, fn, arg1, arg2, value), If arg is an object, use waitForPage(page, options)
  * @param {array} optsOrFn.args - arguments of fn
  * @param {function} optsOrFn.fn - function to evaluate
- * @param {function} optsOrFn.fname - function name (can be set with fn.name on the classic signature)
  * @param {*} optsOrFn.value - expected value of function
  * @param {number} [optsOrFn.timeout=null] - timeout in ms
  * @param {...*} [arguments]
@@ -1656,7 +1655,7 @@ function waitForPage(page, optsOrFn) {
 		  fn = optsOrFn.fn;
 			args = [page, fn].concat(optsOrFn.args || []);
 			value = optsOrFn.value;
-			fname = optsOrFn.fname || fn.name || '<anonymous>';
+			fname = fn.name || '<anonymous>';
 			if(optsOrFn.timeout){
 				timeout = optsOrFn.timeout;
 			}

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1586,6 +1586,8 @@ exports.waitForNextPage = function() {
 /**
  * Wait for a selector to be present on the current page
  * @param {string} - The selector on which to wait.
+ * @param {object} options
+ * @param {number} [options.timeout=undefined] - timeout options
  * @throws Horseman.TimeoutError
  * @emits Horseman#timeout
  */
@@ -1597,18 +1599,28 @@ exports.waitForSelector = function(selector, options) {
 		return els.length > 0;
 	};
 
+	var opts = {
+		fn : elementPresent,
+		args : [selector],
+		value : true
+	};
+
 	if(typeof(options) !== "undefined" && typeof(options.timeout)  === "number"){
-		elementPresent.timeout = options.timeout;
+		opts.timeout = options.timeout;
 	}
 
-	return this.waitFor(elementPresent, selector, true).then(function() {
+	return this.waitFor(opts).then(function() {
 		debug('.waitForSelector() complete');
 	});
 };
 
 /**
  * Waits for a function to evaluate to a given value in browser
- * @param {function} fn
+ * @param {function | object} optsOrFn - If optsOrFn is a function, use the classic signature waitFor(fn, arg1, arg2, value), If arg is an object, use waitFor(options)
+ * @param {array} optsOrFn.args - arguments of fn
+ * @param {function} optsOrFn.fn - function to evaluate
+ * @param {*} optsOrFn.value - expected value of function
+ * @param {number} [optsOrFn.timeout=null] - timeout in ms
  * @param {...*} [arguments]
  * @param {*} value
  * @throws Horseman.TimeoutError
@@ -1621,17 +1633,34 @@ exports.waitFor = function() {
 /**
  * Waits for a function to evaluate to a given value on the given page
  * @param {Page | undefined} page
- * @param {function} fn
+ * @param {function | object} optsOrFn - If optsOrFn is a function, use the classic signature waitForPage(page, fn, arg1, arg2, value), If arg is an object, use waitForPage(page, options)
+ * @param {array} optsOrFn.args - arguments of fn
+ * @param {function} optsOrFn.fn - function to evaluate
+ * @param {function} optsOrFn.fname - function name (can be set with fn.name on the classic signature)
+ * @param {*} optsOrFn.value - expected value of function
+ * @param {number} [optsOrFn.timeout=null] - timeout in ms
  * @param {...*} [arguments]
  * @param {*} value
  * @emits Horseman#TimeoutError
  */
-function waitForPage(page, fn) {
+function waitForPage(page, optsOrFn) {
 	var self = this;
-	var args = Array.prototype.slice.call(arguments);
-	var value = args.pop();
-	var fname = fn.name || '<anonymous>';
-	var timeout = fn.timeout || self.options.timeout;
+	var args, value, fname, timeout = self.options.timeout, fn;
+
+	if(typeof optsOrFn === "function"){
+		  fn = optsOrFn;
+			args = Array.prototype.slice.call(arguments);
+			value = args.pop();
+			fname = fn.name || '<anonymous>';
+	} else if(typeof optsOrFn === "object"){
+		  fn = optsOrFn.fn;
+			args = [page, fn].concat(optsOrFn.args || []);
+			value = optsOrFn.value;
+			fname = optsOrFn.fname || fn.name || '<anonymous>';
+			if(optsOrFn.timeout){
+				timeout = optsOrFn.timeout;
+			}
+	}
 
 	debug.apply(debug, ['.waitFor()', fname].concat(args.slice(2)));
 	return this.ready.then(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1354,7 +1354,6 @@ describe('Horseman', function() {
 					var end = new Date();
 					var diff = end - start;
 					diff.should.be.below(defaultTimeout/2); //may be a ms or so off.
-					return Promise.resolve();
 				});
 		});
 

--- a/test/index.js
+++ b/test/index.js
@@ -1387,6 +1387,26 @@ describe('Horseman', function() {
 				});
 		});
 
+		it('should call onTimeout if timeout in waitForNextPage with custom timeout', function() {
+			var start = new Date();
+			var timeoutHorseman = new Horseman({
+				timeout: 10
+			});
+			var timeoutFiredTime = 0;
+			return timeoutHorseman
+				.on('timeout', function() {
+					var end = new Date();
+					var diff = end - start;
+					timeoutFiredTime = diff;
+				})
+				.waitForNextPage({timeout: 1000})
+				.catch(Horseman.TimeoutError, function() {})
+				.close()
+				.then(function() {
+					timeoutFiredTime.should.be.above(900);
+				});
+		});
+
 		it('should reject Promise if timeout in  waitForNextPage', function() {
 			var timeoutHorseman = new Horseman({
 				timeout: 10

--- a/test/index.js
+++ b/test/index.js
@@ -1341,6 +1341,23 @@ describe('Horseman', function() {
 				});
 		});
 
+		it('should timeout after a specific time', function() {
+			var start = new Date();
+			var horseman = new Horseman({
+				timeout: defaultTimeout,
+			});
+			return horseman
+				.open(serverUrl)
+				.waitForSelector("#not-existing-id", { timeout : defaultTimeout/5})
+				.close()
+				.catch(function(err){
+					var end = new Date();
+					var diff = end - start;
+					diff.should.be.below(defaultTimeout/2); //may be a ms or so off.
+					return Promise.resolve();
+				});
+		});
+
 		it('should wait until a selector is seen', function() {
 			var horseman = new Horseman({
 				timeout: defaultTimeout,


### PR DESCRIPTION
Hello @johntitus,

This pull request is a proposal to fix #250.
Can you please give me a feedback on this ? 

I had a dilemna on how to add this timeout options inside `waitFor`, since the number of arguments of this function is free, i did not want to add one more argument at the end.

I put it into `fn.timeout`, following the design pattern used for `fn.name`.

Another solution would be to implement an alternative signature of `waitFor` which looks like : 

```javascript
waitFor({
  fn : fn,
  args : args,
  value : value
})
```

Please share your thoughts on this.

Best regards